### PR TITLE
extract-files: Bring back old behavior for SRC

### DIFF
--- a/build/templates/extract-files.sh
+++ b/build/templates/extract-files.sh
@@ -39,14 +39,13 @@ CLEAN_VENDOR=true
 
 while [ "$1" != "" ]; do
     case $1 in
-        -p | --path )           shift
-                                SRC=$1
+        -n | --no-cleanup )     CLEAN_VENDOR=false
                                 ;;
         -s | --section )        shift
                                 SECTION=$1
                                 CLEAN_VENDOR=false
                                 ;;
-        -n | --no-cleanup )     CLEAN_VENDOR=false
+        * )                     SRC=$1
                                 ;;
     esac
     shift


### PR DESCRIPTION
* Previously, you could just specify a SRC directly
  after './extract-files', and it would work, but
  now, the arg '-p/--path' is required for the same
  behavior to be applied for the extraction
* Add a catch-all case that just sets SRC if the arg
  doesn't match any of the args that we care about
* Make the ordering of the cases alphabetical

Change-Id: Ia2ad42d444904ead6b3bd6d910af363eb7f015cc